### PR TITLE
updated s_fps.sqf to also log object and player count

### DIFF
--- a/SQF/dayz_server/system/s_fps.sqf
+++ b/SQF/dayz_server/system/s_fps.sqf
@@ -1,4 +1,4 @@
 while {isServer} do {
-	diag_log ("DEBUG FPS  : " + str(diag_fps) );
-	sleep 360;
+        diag_log format["DEBUG FPS : %1 OBJECTS: %2 : PLAYERS: %3", diag_fps,(count (allMissionObjects "")),(playersNumber west)];
+        sleep 60;
 };

--- a/SQF/dayz_server/system/server_monitor.sqf
+++ b/SQF/dayz_server/system/server_monitor.sqf
@@ -1,5 +1,5 @@
 private ["_date","_year","_month","_day","_hour","_minute","_date1","_hiveResponse","_key","_objectCount","_dir","_point","_i","_action","_dam","_selection","_wantExplosiveParts","_entity","_worldspace","_damage","_booleans","_rawData","_ObjectID","_class","_CharacterID","_inventory","_hitpoints","_fuel","_id","_objectArray","_script","_result","_outcome"];
-//[]execVM "\z\addons\dayz_server\system\s_fps.sqf"; //server monitor FPS (writes each ~181s diag_fps+181s diag_fpsmin*)
+//[]execVM "\z\addons\dayz_server\system\s_fps.sqf"; //server monitor - log fps, objects and player count
 #include "\z\addons\dayz_server\compile\server_toggle_debug.hpp"
 
 waitUntil{!isNil "BIS_MPF_InitDone"};


### PR DESCRIPTION
I use this to track/graph fps and object count in my monitoring system. It only adds to the existing diag_log line and is still disabled by default in server_monitor.sqf.
