### PR TITLE
Fixed: Random Survivor Skin onNewLogin

### DIFF
--- a/SQF/dayz_server/compile/server_playerLogin.sqf
+++ b/SQF/dayz_server/compile/server_playerLogin.sqf
@@ -134,6 +134,11 @@ if (!_isNew) then {
 		if (_model == "") then {
 			_model = "Survivor2_DZ";
 		};
+	// on new character if not female; randomize male survivor skin
+	
+	if (_model == "Survivor2_DZ") then {
+		_model = ["Survivor1_DZ","Survivor2_DZ"] call BIS_fnc_selectRandom;	
+	};
 	};
 
 	//Record initial inventory


### PR DESCRIPTION
- Re-Adds simple randomization for 2 Common Male Survivor Skins upon new
  character creation

--- Examples ---
- Survivor1_DZ       http://goo.gl/d7nGkt
- Survivor2_DZ       http://goo.gl/KD8z0g
- player_monitor.fsm always passes "Survivor2_DZ" when Male gender is selected. We check for this being passed and then re-assign randomly. 
