### PR TITLE
Random door states on server restart

### DIFF
--- a/SQF/Missions/dayz_1337.chernarus/init.sqf
+++ b/SQF/Missions/dayz_1337.chernarus/init.sqf
@@ -18,6 +18,7 @@ dayz_enableRules = true; //Enables a nice little news/rules feed on player login
 dayz_quickSwitch = false; //Turns on forced animation for weapon switch. (hotkeys 1,2,3) False = enable animations, True = disable animations
 dayz_bleedingeffect = 3; //1= blood on the ground, 2= partical effect, 3 = both.
 dayz_ForcefullmoonNights = false; // Forces night time to be full moon.
+dayz_randomDoorStates = true; // Building doors are randomly open/closed on server restarts
 dayz_POIs = true;
 dayz_infectiousWaterholes = true;
 dayz_DamageMultiplier = 1; //Damage Multiplier for Zombies.

--- a/SQF/dayz_code/init/variables.sqf
+++ b/SQF/dayz_code/init/variables.sqf
@@ -430,6 +430,10 @@ if(isNil "dayz_maxGlobalZeds") then {
 	dayz_maxGlobalZeds = 1000;
 };
 
+if (isNil "dayz_randomDoorStates") then {
+	dayz_randomDoorStates = true;
+};
+
 //init global arrays for Loot Chances
 call compile preprocessFileLineNumbers "\z\addons\dayz_code\init\loot_init.sqf";
 

--- a/SQF/dayz_server/system/server_monitor.sqf
+++ b/SQF/dayz_server/system/server_monitor.sqf
@@ -334,6 +334,24 @@ if (dayz_serversideloot) then {
 };
 */
 
+if (dayz_randomDoorStates) then {
+
+	_houses = (getMarkerPos "center") nearObjects ["Building", 10000];
+	_doorStates = ["dvere","dvere1l","dvere1r","dvere2l","dvere2r","dvere_spodni_r","dvere_spodni_l","dvere_vrchni","vrata1","vrata2","vratal1","vratar1","vratal2","vratar2","vratal3","vratar3","door","door_1_1","door_1_2","door_2_1","door_2_2","dvere1","dvere2","dvere3","dvere4","dvere5","dvere6","dvere7","dvere8","dvere9","dvere10","dvere11","dvere12","dvere13","dvere14","doorl","doorr","door_01","door01_a","door_02","door02_a","door_03","door_04","door_05","door_06","door_1a","door_1","door_2"];
+
+	{
+		_y = _x;
+
+		{
+			_y animate [format ["%1", _x], floor (random 2)];
+		} foreach _doorStates;
+		
+		sleep 0.0001;
+
+	} foreach _houses;
+
+};
+
 "PVDZ_sec_atp" addPublicVariableEventHandler { 
 	_x = _this select 1;
 	switch (1==1) do {


### PR DESCRIPTION
When the server restarts, the doors all around the map will be randomly open/closed.

This can be enabled/disabled in mission file.

This does not include the custom basebuilding gates.
