### PR TITLE
add call to dayz_recordLogin on player disconnect

### DIFF
--- a/SQF/dayz_server/compile/server_onPlayerDisconnect.sqf
+++ b/SQF/dayz_server/compile/server_onPlayerDisconnect.sqf
@@ -30,6 +30,8 @@ if (!isNull _playerObj) then {
 		(getPosATL _playerObj) call fa_coor2str,
 		if ((_lastDamage > 5 AND (_lastDamage < 30)) AND ((alive _playerObj) AND (_playerObj distance (getMarkerpos "respawn_west") >= 2000))) then {" while in combat ("+str(_lastDamage)+" seconds left)"} else {""}
 	]; 
+
+	[_playerUID,_characterID,2] call dayz_recordLogin;
 #endif
 	//Update Vehicle
 	if (vehicle _playerObj != _playerObj) then {


### PR DESCRIPTION
I find this information useful sometimes when investigating, maybe someone else will as well. It's been missing from the code base for quite a while. If there's a good reason it was removed then just ignore.
