### PR TITLE
Bugfix fnc_usec_damageUnconscious

### DIFF
--- a/SQF/dayz_code/medical/setup_functions_med.sqf
+++ b/SQF/dayz_code/medical/setup_functions_med.sqf
@@ -69,11 +69,11 @@ fnc_usec_damageUnconscious = {
 				_unit action ["eject", _veh];
 				waitUntil{((vehicle _this) != _this)};
 				sleep 1;
-				_unit playActionNow "Die";
+				_unit switchMove "AmovPpneMrunSnonWnonDfr";
 			};
 		};
 	} else {
-		_unit playActionNow "Die";
+		_unit switchMove "AmovPpneMrunSnonWnonDfr";
 	};
 };
 


### PR DESCRIPTION
playactionow command causes worldspace desynchronisation and animation state desynchronisation among clients and server.

player appears on ground for other players while the player that recovered from unconsciouness state is running about invisible to others.
