### PR TITLE
update for #742

### DIFF
--- a/SQF/dayz_code/actions/player_chopWood.sqf
+++ b/SQF/dayz_code/actions/player_chopWood.sqf
@@ -108,13 +108,14 @@ if (count _findNearestTree > 0) then {
         cutText [format [localize "str_player_24_progress", _counter,_countOut], "PLAIN DOWN"];
     };
 
-    if (_proceed) then {            
+   if (_proceed ||(_counter > 0) ) then {            
 		//remove vehicle, Need to ask server to remove.
 		PVDZ_objgather_Knockdown = [_tree,player];
 		publicVariableServer "PVDZ_objgather_Knockdown";         
         //cutText [format["\n\nChopping down tree.], "PLAIN DOWN"];
         //cutText [localize "str_player_25", "PLAIN DOWN"];
-    } else {
+	};
+    if !(_proceed) then {            
         cutText [localize "str_player_24_Stoped", "PLAIN DOWN"];
 
         r_interrupt = false;


### PR DESCRIPTION
update for #742
tree should fall down if _any_ logs have been harvested from it. This will prevent people from chopping less than max logs and backing away so they can continually harvest from the same tree.  I have tested this with backing away before harvesting, during harvesting and after harvesting is complete. I have not gotten a broken hatchet yet, but it should not matter.
With that said since this is a core action needed for survival and base building, some focused testing in the next build should be done.
