### PR TITLE
Work around long inventory/hitpoints string

### DIFF
--- a/SQF/dayz_server/init/server_functions.sqf
+++ b/SQF/dayz_server/init/server_functions.sqf
@@ -115,7 +115,7 @@ server_hiveReadWrite = {
 	//diag_log ("ATTEMPT READ/WRITE: " + _key);
 	_data = "HiveExt" callExtension _key;
 	//diag_log ("READ/WRITE: " +str(_data));
-	_resultArray = call compile format ["%1",_data];
+	_resultArray = call compile str formatText["%1", _data];
 	_resultArray
 };
 


### PR DESCRIPTION
Since inventory and hitpoints field in database is of type longtext there is a potential problem here. According to the BI wiki `format` has a limit of 8191 characters. If the player puts many different materials in a large vehicle (for example Ural) this string can become longer and the vehicle does not respawn after server restart.
