### PR TITLE
use aimpos for _exitPosition

### DIFF
--- a/SQF/dayz_code/compile/vehicle_getOut.sqf
+++ b/SQF/dayz_code/compile/vehicle_getOut.sqf
@@ -6,13 +6,13 @@ _vehicle = _this select 0;
 _position = _this select 1;
 _unit = _this select 2;
 
-//Get players current location
-_playerPos = ATLToASL (_unit modelToWorld [0,0,0]);
+//Get players current location (add 1m to z)
+_playerPos = ATLToASL (_unit modelToWorld [0,0,1]);
 
 _fencesArray = ["WoodenFence_1","WoodenFence_2","WoodenFence_3","WoodenFence_4","WoodenFence_5","WoodenFence_6","WoodenFence_7","WoodenGate_1","WoodenGate_2","WoodenGate_3","WoodenGate_4"];
 
-//Hopefully returns the xyz of the vehicle seat pos.
-_exitPosition = ATLToASL (_vehicle modelToWorld (_vehicle selectionPosition ("pos " + _position)));
+//Returns the vehicle model aimpoint.
+_exitPosition = aimPos _vehicle;
 
 if (_unit == player) then {
 	//if (dayz_soundMuted) then {call player_toggleSoundMute;}; // Auto disable mute on vehicle exit (not a good idea without a sleep since rotor can be very loud when spinning down)


### PR DESCRIPTION
`_unit modelToWorld [0,0,0]` returns the position of the players feet. This could lead to glitch under the gate maybe, if the difference in height between player, vehicle and gate allows it.

Using `selectionPosition` with "pos driver" (or other positions in the vehicle) doesn't really work since "pos driver" references the entry point, not the seat coordinates. Entry point depends on the vehicle, but can be far outside of the vehicle. If you drive very close to a fence, it happens that entry point is inside the base. Then there is no intersected objects and the player can still glitch into the base. I tested this by adding 10cm spheres upon getout. With an SUV the player position (after getout) and the "pos driver" position only differ in a few millimeters.

The idea using `aimPos` was "stolen" from epoch. @ebayShopper please forgive me.