### PR TITLE
fix "distancefoot" bug

### DIFF
--- a/SQF/dayz_server/compile/server_playerSetup.sqf
+++ b/SQF/dayz_server/compile/server_playerSetup.sqf
@@ -244,7 +244,7 @@ dayz_players set [count dayz_players,_playerObj];
 _playerObj setVariable["characterID",_characterID,true];
 _playerObj setVariable["humanity",_humanity,true];
 _playerObj setVariable["humanity_CHK",_humanity];
-_playerObj setVariable["lastPos",getPosATL _playerObj];
+_playerObj setVariable["lastPos",_position];
 
 if (!isNil "faco_hook_playerSetup") then {
 	[_worldspace,_state,_playerObj, _characterID] call faco_hook_playerSetup;


### PR DESCRIPTION
I noticed one error in the calculation of "distancefoot"

 2:57:18 "INFO - Player: PID#3(Dihan)(UID:76561198081029081/CID:129) Status: LOGGING IN"
 2:57:18 "B 1-1-A:1 (Dihan) REMOTE, dayzSetDate, [B 1-1-A:1 (Dihan) REMOTE], 3"
 2:57:18 "B 1-1-A:1 (Dihan) REMOTE, dayzSetDate, [B 1-1-A:1 (Dihan) REMOTE], 3"
 2:57:20 "INFO - Player: PID#3(Dihan)(UID:76561198081029081/CID:129) Status: LOGIN PUBLISHING, Location Мыс Крутой [135105]"
 2:57:31 "INFO - Player: Dihan(UID:76561198081029081/CID:129) Status: CLIENT LOADED & PLAYING"
 2:57:39 "Server_getStatsDiff - Object:B 1-1-B:1 (Dihan) REMOTE Diffs:[0,0,0,0,0] New:[2500,0,0,0,0]"
 2:57:39 "INFO - Dihan(UID:76561198081029081,CID:129) PlayerSync, CHILD:201:129:[285,[13533.2,4805.2,0.00146818]]:[]:["",[[],[]],[[],[]]]:[false,false,false,false,false,false,false,12000,[],[0,0],0,"O",true,[0,0,0],false]:false:false:0:0:38470:0:[["","amovpercmrunsnonwnondf",36],[]]:0:0:"Survivor2_DZ":0:"

Note the distance 38470 is the distance from the wasteland to the player's spawn point. This violates the actual calculation of the distance traveled every time a player logs on to the server.